### PR TITLE
Add empty stub methods to fix NativeEventEmitter warnings

### DIFF
--- a/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
+++ b/android/src/main/java/net/no_mad/tts/TextToSpeechModule.java
@@ -433,6 +433,16 @@ public class TextToSpeechModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(double count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     /**
      * called on React Native Reloading JavaScript
      * https://stackoverflow.com/questions/15563361/tts-leaked-serviceconnection


### PR DESCRIPTION
Follows unmerged PRs to prevent warnings: 

- https://github.com/ak1394/react-native-tts/pull/216
- https://github.com/ak1394/react-native-tts/pull/227